### PR TITLE
1차 자율주행 코드 센서 변경

### DIFF
--- a/altino.c
+++ b/altino.c
@@ -1,73 +1,57 @@
 #include "Altino.h"
 #include <stdio.h>
 
+SensorData sdata; //센서를 이용하기 위한 선언
+
+
 int main() {
-	Open(szPort);
+
+	Open(szPort); // 블루투스 연결
+
+
+
 	while (1) {
 
-		SensorData sdata;
 		Sendbuf[21] = 10;
-		sdata = Sensor(1);
+		sdata = Sensor(1); // 센서값을 부르기 위한 함수
 
-		printf("IR1 : %d, IR2 : %d\n", sdata.IRSensor[0], sdata.IRSensor[1]);
-		printf("IR3 : %d, IR4 : %d\n", sdata.IRSensor[2], sdata.IRSensor[3]);
-		printf("IR5 : %d, IR6 : %d\n", sdata.IRSensor[4], sdata.IRSensor[5]);
-
-		if (sdata.IRSensor[3]>20) {
+		if (sdata.IRSensor[2] > 16) { // [2]번 센서와 벽의 거리가 약 3CM정도 보다 가까우면 좌회전
 
 
-			Steering(1);
-			Go(300, 300);
-			delay(50);
+			Steering(1); //좌회전
 
-			if (sdata.IRSensor[2]>20) {
-
-				Steering(1);
-				Go(300, 300);
-				delay(300);
-
-			}
-
-			if (sdata.IRSensor[2]>300) {
-
-				Steering(3);
-				Go(-300, -300);
-				delay(700);
-
-				Steering(2);
-				Go(300, 300);
-				delay(50);
-			}
-
-			Sendbuf[21] = 10;
-			sdata = Sensor(1);
+			Go(290, 290); //뒷바퀴 속도 290,290
 
 		}
 
-		if (sdata.IRSensor[3]<20) {
+		if (sdata.IRSensor[2] <= 16 && sdata.IRSensor[2] > 8) { // [2]번 센서와 벽의 거리가 약 3~5CM일경우 직진
 
-			Steering(2);
-			Go(300, 300);
-			delay(50);
 
-			if (sdata.IRSensor[2]>20) {
+			Steering(2); //전진
 
-				Steering(1);
-				Go(300, 300);
-				delay(300);
+			Go(290, 290); //뒷바퀴 속도 290,290
 
-			}
-
-			if (sdata.IRSensor[2]>300) {
-
-				Steering(3);
-				Go(-300, -300);
-				delay(700);
-
-				Steering(2);
-				Go(300, 300);
-				delay(50);
-			}
 		}
+
+		if (sdata.IRSensor[2] <= 8) { // [2]번 센서와 벽의 거리가 약 5CM일경우 벽에 붙기 위해 우회전
+
+
+			Steering(3); //우회전
+
+			Go(290, 290); // 뒷바퀴 속도 290,290
+
+		}
+
+		if (sdata.IRSensor[4] >= 600) { // 알티노 주행의 종료 조건 IR [4번] 센서를 손으로 잡는다.
+
+			break;
+		}
+
+
 	}
+
+Close(); //알티노와의 연결을 끊는다.
+
+return 0;
+
 }


### PR DESCRIPTION
기존 1차코드에서는 센서 [3]을 이용해 벽면을 따라갔었는데, 그렇게하면 막히는 경우가 많아서 센서 [2]를 이용하는것으로 변경.